### PR TITLE
Consensus timer

### DIFF
--- a/Builds/VisualStudio2015/RippleD.vcxproj
+++ b/Builds/VisualStudio2015/RippleD.vcxproj
@@ -4573,6 +4573,8 @@
     </ClInclude>
     <ClInclude Include="..\..\src\test\csf\submitters.h">
     </ClInclude>
+    <ClInclude Include="..\..\src\test\csf\timers.h">
+    </ClInclude>
     <ClInclude Include="..\..\src\test\csf\TrustGraph.h">
     </ClInclude>
     <ClInclude Include="..\..\src\test\csf\Tx.h">

--- a/Builds/VisualStudio2015/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2015/RippleD.vcxproj.filters
@@ -5334,6 +5334,9 @@
     <ClInclude Include="..\..\src\test\csf\submitters.h">
       <Filter>test\csf</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\test\csf\timers.h">
+      <Filter>test\csf</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\src\test\csf\TrustGraph.h">
       <Filter>test\csf</Filter>
     </ClInclude>

--- a/src/test/consensus/ScaleFreeSim_test.cpp
+++ b/src/test/consensus/ScaleFreeSim_test.cpp
@@ -20,6 +20,7 @@
 #include <ripple/beast/clock/manual_clock.h>
 #include <ripple/beast/unit_test.h>
 #include <test/csf.h>
+#include <test/csf/random.h>
 #include <utility>
 
 namespace ripple {
@@ -123,7 +124,7 @@ class ScaleFreeSim_test : public beast::unit_test::suite
         sim.run(1);
 
         // Initialize timers
-        HeartbeatTimer heart(sim.scheduler);
+        HeartbeatTimer heart(sim.scheduler, seconds(10s));
 
         // Run for 10 minues, submitting 100 tx/second
         std::chrono::nanoseconds simDuration = 10min;
@@ -131,10 +132,12 @@ class ScaleFreeSim_test : public beast::unit_test::suite
         Rate rate{100, 1000ms};
 
         // txs, start/stop/step, target
+        std::vector<Peer*> peers{network.begin(), network.end()};
+        auto peerSelector = selector(peers, ranks, sim.rng);
         auto txSubmitter = submitter(ConstantDistribution{rate.inv()},
                           sim.scheduler.now() + quiet,
                           sim.scheduler.now() + (simDuration - quiet),
-                          *(*network.begin()),
+                          peerSelector,
                           sim.scheduler,
                           sim.rng);
 

--- a/src/test/consensus/ScaleFreeSim_test.cpp
+++ b/src/test/consensus/ScaleFreeSim_test.cpp
@@ -132,8 +132,10 @@ class ScaleFreeSim_test : public beast::unit_test::suite
         Rate rate{100, 1000ms};
 
         // txs, start/stop/step, target
-        std::vector<Peer*> peers{network.begin(), network.end()};
-        auto peerSelector = selector(peers, ranks, sim.rng);
+        auto peerSelector = selector(network.begin(),
+                                     network.end(),
+                                     ranks,
+                                     sim.rng);
         auto txSubmitter = submitter(ConstantDistribution{rate.inv()},
                           sim.scheduler.now() + quiet,
                           sim.scheduler.now() + (simDuration - quiet),

--- a/src/test/csf.h
+++ b/src/test/csf.h
@@ -32,3 +32,4 @@
 #include <test/csf/ledgers.h>
 #include <test/csf/random.h>
 #include <test/csf/submitters.h>
+#include <test/csf/timers.h>

--- a/src/test/csf/Peer.h
+++ b/src/test/csf/Peer.h
@@ -766,7 +766,7 @@ struct Peer
         consensus.timerEntry(now());
         // only reschedule if not completed
         if (completedLedgers < targetLedgers)
-            scheduler.in(parms().ledgerGRANULARITY, [&]() { timerEntry(); });
+            scheduler.in(parms().ledgerGRANULARITY, [this]() { this->timerEntry(); });
     }
 
     void

--- a/src/test/csf/Peer.h
+++ b/src/test/csf/Peer.h
@@ -766,7 +766,7 @@ struct Peer
         consensus.timerEntry(now());
         // only reschedule if not completed
         if (completedLedgers < targetLedgers)
-            scheduler.in(parms().ledgerGRANULARITY, [this]() { this->timerEntry(); });
+            scheduler.in(parms().ledgerGRANULARITY, [this]() { timerEntry(); });
     }
 
     void

--- a/src/test/csf/SimTime.h
+++ b/src/test/csf/SimTime.h
@@ -27,6 +27,10 @@ namespace ripple {
 namespace test {
 namespace csf {
 
+using RealClock = std::chrono::system_clock;
+using RealDuration = RealClock::duration;
+using RealTime = RealClock::time_point;
+
 using SimClock = beast::manual_clock<std::chrono::steady_clock>;
 using SimDuration = typename SimClock::duration;
 using SimTime = typename SimClock::time_point;

--- a/src/test/csf/random.h
+++ b/src/test/csf/random.h
@@ -103,14 +103,6 @@ selector(Iter first, Iter last, std::vector<double>& w, Generator& g)
     return Selector<Iter, Generator>(first, last, w, g);
 }
 
-template < typename T, typename Generator>
-Selector<typename std::vector<T>::iterator,Generator>
-selector(std::vector<T>& v, std::vector<double>& w, Generator& g)
-{
-    return Selector<typename std::vector<T>::iterator, Generator>(
-            v.begin(), v.end(), w, g);
-}
-
 //------------------------------------------------------------------------------
 // Additional distrubtions of interest not defined in in <random>
 

--- a/src/test/csf/random.h
+++ b/src/test/csf/random.h
@@ -83,16 +83,10 @@ public:
     }
 
     T&
-    select()
+    operator()()
     {
         auto idx = dd_(g_);
         return v_[idx];
-    }
-
-    T&
-    operator()()
-    {
-        return select();
     }
 };
 

--- a/src/test/csf/random.h
+++ b/src/test/csf/random.h
@@ -69,6 +69,39 @@ sample( std::size_t size, PDF pdf, Generator& g)
     std::generate(res.begin(), res.end(), [&pdf, &g]() { return pdf(g); });
     return res;
 }
+template <class T, class Generator>
+class Selector
+{
+    std::vector<T>& v_;
+    std::discrete_distribution<> dd_;
+    Generator g_;
+
+public:
+    Selector(std::vector<T>& v, std::vector<double>& w, Generator& g)
+      : v_{v}, dd_{w.begin(), w.end()}, g_{g}
+    {
+    }
+
+    T&
+    select()
+    {
+        auto idx = dd_(g_);
+        return v_[idx];
+    }
+
+    T&
+    operator()()
+    {
+        return select();
+    }
+};
+
+template < typename T, typename Generator>
+Selector<T,Generator>
+selector(std::vector<T>& v, std::vector<double>& w, Generator& g)
+{
+    return Selector<T,Generator>(v,w,g);
+}
 
 //------------------------------------------------------------------------------
 // Additional distrubtions of interest not defined in in <random>

--- a/src/test/csf/submitters.h
+++ b/src/test/csf/submitters.h
@@ -58,13 +58,13 @@ struct Rate
             arithmetic T to SimDuration::rep units to allow using standard
             library distributions as a Distribution.
 */
-template <class Distribution, class Generator>
+template <class Distribution, class Generator, class Selector>
 class Submitter
 {
     Distribution dist_;
     SimTime stop_;
     std::uint32_t nextID_ = 0;
-    Peer & target_;
+    Selector & selector_;
     Scheduler & scheduler_;
     Generator & g_;
 
@@ -87,7 +87,7 @@ class Submitter
     void
     submit()
     {
-        target_.submit(Tx{nextID_++});
+        selector_()->submit(Tx{nextID_++});
         if (scheduler_.now() < stop_)
         {
             scheduler_.in(asDuration(dist_(g_)), [&]() { submit(); });
@@ -99,26 +99,27 @@ public:
         Distribution dist,
         SimTime start,
         SimTime end,
-        Peer & t,
+        Selector & selector,
         Scheduler & s,
         Generator & g)
-        : dist_{dist}, stop_{end}, target_{t}, scheduler_{s}, g_{g}
+        : dist_{dist}, stop_{end}, selector_{selector}, scheduler_{s}, g_{g}
     {
         scheduler_.at(start, [&]() { submit(); });
     }
 };
 
-template <class Distribution, class Generator>
-Submitter<Distribution, Generator>
+template <class Distribution, class Generator, class Selector>
+Submitter<Distribution, Generator, Selector>
 submitter(
     Distribution dist,
     SimTime start,
     SimTime end,
-    Peer& t,
+    Selector& sel,
     Scheduler& s,
     Generator& g)
 {
-    return Submitter<Distribution, Generator>(dist, start ,end, t, s, g);
+    return Submitter<Distribution, Generator, Selector>(
+            dist, start ,end, sel, s, g);
 }
 
 }  // namespace csf

--- a/src/test/csf/submitters.h
+++ b/src/test/csf/submitters.h
@@ -64,7 +64,7 @@ class Submitter
     Distribution dist_;
     SimTime stop_;
     std::uint32_t nextID_ = 0;
-    Selector & selector_;
+    Selector selector_;
     Scheduler & scheduler_;
     Generator & g_;
 

--- a/src/test/csf/timers.h
+++ b/src/test/csf/timers.h
@@ -1,0 +1,78 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012-2017 Ripple Labs Inc
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+#ifndef RIPPLE_TEST_CSF_TIMERS_H_INCLUDED
+#define RIPPLE_TEST_CSF_TIMERS_H_INCLUDED
+
+#include <chrono>
+#include <ostream>
+#include <test/csf/Scheduler.h>
+#include <test/csf/SimTime.h>
+
+namespace ripple {
+namespace test {
+namespace csf {
+
+/** Gives heartbeat of simulation to signal simulation progression
+ */
+using namespace std::chrono;
+class HeartbeatTimer
+{
+    Scheduler & scheduler_;
+    SimDuration interval_;
+
+    RealTime startRealTime_;
+    SimTime startSimTime_;
+
+public:
+    HeartbeatTimer(Scheduler& sched, SimDuration interval = 60s)
+            : scheduler_{sched}, interval_{interval},
+              startRealTime_{RealClock::now()},
+              startSimTime_{sched.now()}
+    {
+    };
+
+    inline void
+    start()
+    {
+        scheduler_.in(interval_, [this](){this->beat(scheduler_.now());});
+    };
+
+    inline void
+    beat(SimTime when)
+    {
+        RealTime realTime = RealClock::now();
+        SimTime simTime = when;
+
+        RealDuration realDuration = realTime - startRealTime_;
+        SimDuration simDuration = simTime - startSimTime_;
+        std::cout << "Heartbeat. Time Elapsed: {sim: "
+                  << duration_cast<seconds>(simDuration).count()
+                  << "s | real: "
+                  << duration_cast<seconds>(realDuration).count()
+                  << "s}\n" << std::flush;
+
+        scheduler_.in(interval_, [this](){this->beat(scheduler_.now());});
+    }
+};
+
+}  // namespace csf
+}  // namespace test
+}  // namespace ripple
+
+#endif

--- a/src/test/csf/timers.h
+++ b/src/test/csf/timers.h
@@ -30,7 +30,6 @@ namespace csf {
 
 /** Gives heartbeat of simulation to signal simulation progression
  */
-using namespace std::chrono;
 class HeartbeatTimer
 {
     Scheduler & scheduler_;
@@ -40,22 +39,25 @@ class HeartbeatTimer
     SimTime startSimTime_;
 
 public:
-    HeartbeatTimer(Scheduler& sched, SimDuration interval = 60s)
+    HeartbeatTimer(
+            Scheduler& sched,
+            SimDuration interval = std::chrono::seconds(60s))
             : scheduler_{sched}, interval_{interval},
               startRealTime_{RealClock::now()},
               startSimTime_{sched.now()}
     {
     };
 
-    inline void
+    void
     start()
     {
-        scheduler_.in(interval_, [this](){this->beat(scheduler_.now());});
+        scheduler_.in(interval_, [this](){beat(scheduler_.now());});
     };
 
-    inline void
+    void
     beat(SimTime when)
     {
+        using namespace std::chrono;
         RealTime realTime = RealClock::now();
         SimTime simTime = when;
 
@@ -67,7 +69,7 @@ public:
                   << duration_cast<seconds>(realDuration).count()
                   << "s}\n" << std::flush;
 
-        scheduler_.in(interval_, [this](){this->beat(scheduler_.now());});
+        scheduler_.in(interval_, [this](){beat(scheduler_.now());});
     }
 };
 


### PR DESCRIPTION
Changes:

- Added `HeartbeatTimer` in order to periodically print simulation time passed to give user feedback during lock simulations
  - `HeartbeatTimer::start(..)` must be called after `sim.run(1)` 
- Added `Selector` to allow for probabilistic selection of peer to submit transactions to
  - In `ScaleFreeSim` transactions are submitted according to peers "ranks"